### PR TITLE
WIP infectionType

### DIFF
--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -73,15 +73,7 @@ public class DefaultInfectionModel extends InfectionModel {
                 continue;
             }
 
-            // keep track of contacts:
-            if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
-                if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {
-                    personLeavingContainer.addTraceableContactPerson(otherPerson);
-                }
-                if (!otherPerson.getTraceableContactPersons().contains(personLeavingContainer)) {
-                    otherPerson.addTraceableContactPerson(personLeavingContainer);
-                }
-            }
+            trackOtherPerson(personLeavingContainer, infectionType, otherPerson);
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());
@@ -132,6 +124,18 @@ public class DefaultInfectionModel extends InfectionModel {
                 } else {
                     infectPerson(otherPerson, personLeavingContainer, now, infectionType);
                 }
+            }
+        }
+    }
+
+    private void trackOtherPerson(EpisimPerson personLeavingContainer, String infectionType, EpisimPerson otherPerson) {
+        // keep track of contacts:
+        if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
+            if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {
+                personLeavingContainer.addTraceableContactPerson(otherPerson);
+            }
+            if (!otherPerson.getTraceableContactPersons().contains(personLeavingContainer)) {
+                otherPerson.addTraceableContactPerson(personLeavingContainer);
             }
         }
     }

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -80,7 +80,7 @@ public class DefaultInfectionModel extends InfectionModel {
                 continue;
             }
 
-            trackOtherPerson(personLeavingContainer, infectionType, otherPerson);
+            trackContactPerson(personLeavingContainer, infectionType, otherPerson);
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());
@@ -135,7 +135,7 @@ public class DefaultInfectionModel extends InfectionModel {
         }
     }
 
-    private void trackOtherPerson(EpisimPerson personLeavingContainer, String infectionType, EpisimPerson otherPerson) {
+    private void trackContactPerson(EpisimPerson personLeavingContainer, String infectionType, EpisimPerson otherPerson) {
         // keep track of contacts:
         if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
             if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -46,10 +46,15 @@ public class DefaultInfectionModel extends InfectionModel {
 
         // For the time being, will just assume that the first 10 persons are the ones we interact with.  Note that because of
         // shuffle, those are 10 different persons every day.
+        // as sample size is 25%, 10 persons means 3 agents here
+        int contactPersonsToFind = Math.max((int) (episimConfig.getSampleSize() * 10), 3);
+        for ( int ii = 0 ; ii< personsToInteractWith.size(); ii++ ) {
+            //as we now forbid infection for certain activity type pairs, we do need the separate counter. schlenther, march 27
 
-        // persons are scaled to number of agents with sample size, but at least 3 for the small development scenarios
-        int contactWith = Math.min(personsToInteractWith.size(), Math.max((int) (episimConfig.getSampleSize() * 10), 3));
-        for (int ii = 0; ii < contactWith; ii++) {
+            //if we have seen enough, break, no matter what
+            if(contactPersonsToFind <= 0){
+                break;
+            }
 
             // (this is "-1" because we can't interact with "self")
 
@@ -60,6 +65,8 @@ public class DefaultInfectionModel extends InfectionModel {
             //TODO the way we iterate here, chances exist that we do draw the same otherPerson twice, right? schlenther, march 27
             int idx = rnd.nextInt(personsToInteractWith.size());
             EpisimPerson otherPerson = personsToInteractWith.get(idx);
+
+            contactPersonsToFind --;
 
             // (we count "quarantine" as well since they essentially represent "holes", i.e. persons who are no longer there and thus the
             // density in the transit container goes down.  kai, mar'20)


### PR DESCRIPTION
in the snz scenario, agents can perform activities of different types in the same episimcontainer.
we might want to forbid infection for certain activity type pairs such as home <-> shopping.

when different activity types are allowed, the defined contact intentisities can differ.
