### PR TITLE
WIP: avoid certain cross-activity infections

### DIFF
--- a/src/main/java/org/matsim/episim/EpisimReporting.java
+++ b/src/main/java/org/matsim/episim/EpisimReporting.java
@@ -239,7 +239,7 @@ public final class EpisimReporting {
             return nSusceptible + nTotalInfected + nRecovered;
         }
 
-        public void scale(double factor) {
+        void scale(double factor) {
             nSusceptible *= factor;
             nInfectedButNotContagious *= factor;
             nContagious *= factor;

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -149,7 +149,6 @@ public class DefaultInfectionModel extends InfectionModel {
     }
 
     private double getContactIntensity(EpisimContainer<?> container, InfectionSituation infectionSituation, String leavingPersonsActivity, String otherPersonsActivity) {
-        //TODO maybe this can be cleaned up or summarized in some way
         double contactIntensity = -1;
         if(infectionSituation.equals(InfectionSituation.Vehicle)){
             if(! (container instanceof InfectionEventHandler.EpisimVehicle) ){

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -46,8 +46,10 @@ public class DefaultInfectionModel extends InfectionModel {
 
         // For the time being, will just assume that the first 10 persons are the ones we interact with.  Note that because of
         // shuffle, those are 10 different persons every day.
-        // as sample size is 25%, 10 persons means 3 agents here
-        for ( int ii = 0 ; ii< Math.min(personsToInteractWith.size(),3); ii++ ) {
+
+        // persons are scaled to number of agents with sample size, but at least 3 for the small development scenarios
+        int contactWith = Math.min(personsToInteractWith.size(), Math.max((int) (episimConfig.getSampleSize() * 10), 3));
+        for (int ii = 0; ii < contactWith; ii++) {
 
             // (this is "-1" because we can't interact with "self")
 

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -91,7 +91,7 @@ public class DefaultInfectionModel extends InfectionModel {
             //we can not track contact persons in vehicles
             if (infectionSituation.equals(InfectionSituation.Facility)){
                 //home can only interact with home or leisure
-                if (infectionType.contains("home") && ! infectionType.contains("leis")  && ! ( leavingPersonsActivity.contains("home") && otherPersonsActivity.contains("home")  )){
+                if (infectionType.contains("home") && ! (infectionType.contains("leisure") || infectionType.equals("home_home"))  ){
                     continue;
                 } else if (infectionType.contains("edu") && ! infectionType.contains("work") && ! ( leavingPersonsActivity.contains("edu") && otherPersonsActivity.contains("edu") )){
                     //edu can only interact with work or edu

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -73,15 +73,7 @@ public class DefaultInfectionModel extends InfectionModel {
                 continue;
             }
 
-            // keep track of contacts:
-            if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
-                if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {
-                    personLeavingContainer.addTraceableContactPerson(otherPerson);
-                }
-                if (!otherPerson.getTraceableContactPersons().contains(personLeavingContainer)) {
-                    otherPerson.addTraceableContactPerson(personLeavingContainer);
-                }
-            }
+            trackOtherPerson(personLeavingContainer, infectionType, otherPerson);
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());
@@ -132,6 +124,18 @@ public class DefaultInfectionModel extends InfectionModel {
                 } else {
                     infectPerson(otherPerson, personLeavingContainer, now, infectionType);
                 }
+            }
+        }
+    }
+
+    private void trackOtherPerson(EpisimPerson personLeavingContainer, String infectionType, EpisimPerson otherPerson) {
+        // keep track of contacts:
+        if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
+            if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {
+                personLeavingContainer.addTraceableContactPerson(otherPerson);
+            }
+            if (!otherPerson.getTraceableContactPersons().contains(personLeavingContainer)) {
+                otherPerson.addTraceableContactPerson(personLeavingContainer);
             }
         }
     }

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -58,8 +58,8 @@ public class DefaultInfectionModel extends InfectionModel {
             //  depend on the density), and then a probability of infection in either direction.
 
             //TODO the way we iterate here, chances exist that we do draw the same otherPerson twice, right? schlenther, march 27
-            int idx = rnd.nextInt(container.getPersons().size());
-            EpisimPerson otherPerson = container.getPersons().get(idx);
+            int idx = rnd.nextInt(personsToInteractWith.size());
+            EpisimPerson otherPerson = personsToInteractWith.get(idx);
 
             // (we count "quarantine" as well since they essentially represent "holes", i.e. persons who are no longer there and thus the
             // density in the transit container goes down.  kai, mar'20)

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -47,16 +47,16 @@ public class DefaultInfectionModel extends InfectionModel {
         ArrayList<EpisimPerson> personsToInteractWith = new ArrayList<>(container.getPersons());
         personsToInteractWith.remove(personLeavingContainer);
 
+        int contactPersons = 0;
 
         // For the time being, will just assume that the first 10 persons are the ones we interact with.  Note that because of
         // shuffle, those are 10 different persons every day.
         // as sample size is 25%, 10 persons means 3 agents here
-        int contactPersonsToFind = Math.max((int) (episimConfig.getSampleSize() * 10), 3);
         for ( int ii = 0 ; ii< personsToInteractWith.size(); ii++ ) {
             //as we now forbid infection for certain activity type pairs, we do need the separate counter. schlenther, march 27
 
             //if we have seen enough, break, no matter what
-            if(contactPersonsToFind <= 0){
+            if(contactPersons >= 3){
                 break;
             }
 
@@ -101,7 +101,7 @@ public class DefaultInfectionModel extends InfectionModel {
                 trackContactPerson(personLeavingContainer, otherPerson, leavingPersonsActivity);
             }
 
-            contactPersonsToFind --;
+            contactPersons ++;
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -80,7 +80,7 @@ public class DefaultInfectionModel extends InfectionModel {
                 continue;
             }
 
-            trackOtherPerson(personLeavingContainer, infectionType, otherPerson);
+            trackContactPerson(personLeavingContainer, infectionType, otherPerson);
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());
@@ -135,7 +135,7 @@ public class DefaultInfectionModel extends InfectionModel {
         }
     }
 
-    private void trackOtherPerson(EpisimPerson personLeavingContainer, String infectionType, EpisimPerson otherPerson) {
+    private void trackContactPerson(EpisimPerson personLeavingContainer, String infectionType, EpisimPerson otherPerson) {
         // keep track of contacts:
         if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
             if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -47,16 +47,16 @@ public class DefaultInfectionModel extends InfectionModel {
         ArrayList<EpisimPerson> personsToInteractWith = new ArrayList<>(container.getPersons());
         personsToInteractWith.remove(personLeavingContainer);
 
-        int contactPersons = 0;
 
         // For the time being, will just assume that the first 10 persons are the ones we interact with.  Note that because of
         // shuffle, those are 10 different persons every day.
         // as sample size is 25%, 10 persons means 3 agents here
+        int contactPersonsToFind = Math.max((int) (episimConfig.getSampleSize() * 10), 3);
         for ( int ii = 0 ; ii< personsToInteractWith.size(); ii++ ) {
             //as we now forbid infection for certain activity type pairs, we do need the separate counter. schlenther, march 27
 
             //if we have seen enough, break, no matter what
-            if(contactPersons >= 3){
+            if(contactPersonsToFind <= 0){
                 break;
             }
 
@@ -101,7 +101,7 @@ public class DefaultInfectionModel extends InfectionModel {
                 trackContactPerson(personLeavingContainer, otherPerson, leavingPersonsActivity);
             }
 
-            contactPersons ++;
+            contactPersonsToFind --;
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -91,7 +91,7 @@ public class DefaultInfectionModel extends InfectionModel {
             //we can not track contact persons in vehicles
             if (infectionSituation.equals(InfectionSituation.Facility)){
                 //home can only interact with home or leisure
-                if (infectionType.contains("home") && ! (infectionType.contains("leisure") || infectionType.equals("home_home"))  ){
+                if (infectionType.contains("home") && ! infectionType.contains("leis")  && ! ( leavingPersonsActivity.contains("home") && otherPersonsActivity.contains("home")  )){
                     continue;
                 } else if (infectionType.contains("edu") && ! infectionType.contains("work") && ! ( leavingPersonsActivity.contains("edu") && otherPersonsActivity.contains("edu") )){
                     //edu can only interact with work or edu

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -17,24 +17,21 @@ public class DefaultInfectionModel extends InfectionModel {
 
     private static final Logger log = LogManager.getLogger(DefaultInfectionModel.class);
 
-    private enum InfectionSituation {Vehicle, Facility}
-
     public DefaultInfectionModel(Random rnd, EpisimConfigGroup episimConfig, EpisimReporting reporting) {
         super(rnd, episimConfig, reporting);
     }
 
     @Override
     public void infectionDynamicsVehicle(EpisimPerson personLeavingVehicle, InfectionEventHandler.EpisimVehicle vehicle, double now) {
-//        infectionDynamicsGeneralized(personLeavingVehicle, vehicle, now, vehicle.getContainerId().toString());
-        infectionDynamicsGeneralized(personLeavingVehicle, vehicle, now, InfectionSituation.Vehicle);
+        infectionDynamicsGeneralized(personLeavingVehicle, vehicle, now, vehicle.getContainerId().toString());
     }
 
     @Override
     public void infectionDynamicsFacility(EpisimPerson personLeavingFacility, InfectionEventHandler.EpisimFacility facility, double now, String actType) {
-        infectionDynamicsGeneralized(personLeavingFacility, facility, now, InfectionSituation.Facility);
+        infectionDynamicsGeneralized(personLeavingFacility, facility, now, actType);
     }
 
-    private void infectionDynamicsGeneralized(EpisimPerson personLeavingContainer, EpisimContainer<?> container, double now, InfectionSituation infectionSituation) {
+    private void infectionDynamicsGeneralized(EpisimPerson personLeavingContainer, EpisimContainer<?> container, double now, String infectionType) {
 
         if (iteration == 0) {
             return;
@@ -47,18 +44,12 @@ public class DefaultInfectionModel extends InfectionModel {
         ArrayList<EpisimPerson> personsToInteractWith = new ArrayList<>(container.getPersons());
         personsToInteractWith.remove(personLeavingContainer);
 
-        int contactPersons = 0;
-
         // For the time being, will just assume that the first 10 persons are the ones we interact with.  Note that because of
         // shuffle, those are 10 different persons every day.
-        // as sample size is 25%, 10 persons means 3 agents here
-        for ( int ii = 0 ; ii< personsToInteractWith.size(); ii++ ) {
-            //as we now forbid infection for certain activity type pairs, we do need the separate counter. schlenther, march 27
 
-            //if we have seen enough, break, no matter what
-            if(contactPersons >= 3){
-                break;
-            }
+        // persons are scaled to number of agents with sample size, but at least 3 for the small development scenarios
+        int contactWith = Math.min(personsToInteractWith.size(), Math.max((int) (episimConfig.getSampleSize() * 10), 3));
+        for (int ii = 0; ii < contactWith; ii++) {
 
             // (this is "-1" because we can't interact with "self")
 
@@ -67,8 +58,8 @@ public class DefaultInfectionModel extends InfectionModel {
             //  depend on the density), and then a probability of infection in either direction.
 
             //TODO the way we iterate here, chances exist that we do draw the same otherPerson twice, right? schlenther, march 27
-            int idx = rnd.nextInt(personsToInteractWith.size());
-            EpisimPerson otherPerson = personsToInteractWith.get(idx);
+            int idx = rnd.nextInt(container.getPersons().size());
+            EpisimPerson otherPerson = container.getPersons().get(idx);
 
             // (we count "quarantine" as well since they essentially represent "holes", i.e. persons who are no longer there and thus the
             // density in the transit container goes down.  kai, mar'20)
@@ -82,26 +73,15 @@ public class DefaultInfectionModel extends InfectionModel {
                 continue;
             }
 
-            String leavingPersonsActivity = personLeavingContainer.getTrajectory().get(personLeavingContainer.getCurrentPositionInTrajectory());
-            String otherPersonsActivity = otherPerson.getTrajectory().get(otherPerson.getCurrentPositionInTrajectory());
-
-            String infectionType = leavingPersonsActivity + "_" + otherPersonsActivity;
-
-            //forbid certain cross-activity infections, keep track of contacts
-            //we can not track contact persons in vehicles
-            if (infectionSituation.equals(InfectionSituation.Facility)){
-                //home can only interact with home or leisure
-                if (infectionType.contains("home") && ! (infectionType.contains("leisure") || infectionType.equals("home_home"))  ){
-                    continue;
-                } else if (infectionType.contains("edu") && ! infectionType.contains("work") && ! ( leavingPersonsActivity.contains("edu") && otherPersonsActivity.contains("edu") )){
-                    //edu can only interact with work or edu
-                    continue;
+            // keep track of contacts:
+            if (infectionType.contains("home") || infectionType.contains("work") || (infectionType.contains("leisure") && rnd.nextDouble() < 0.8)) {
+                if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {
+                    personLeavingContainer.addTraceableContactPerson(otherPerson);
                 }
-
-                trackContactPerson(personLeavingContainer, otherPerson, leavingPersonsActivity);
+                if (!otherPerson.getTraceableContactPersons().contains(personLeavingContainer)) {
+                    otherPerson.addTraceableContactPerson(personLeavingContainer);
+                }
             }
-
-            contactPersons ++;
 
             Double containerEnterTimeOfPersonLeaving = container.getContainerEnteringTime(personLeavingContainer.getPersonId());
             Double containerEnterTimeOfOtherPerson = container.getContainerEnteringTime(otherPerson.getPersonId());
@@ -129,8 +109,16 @@ public class DefaultInfectionModel extends InfectionModel {
                 throw new IllegalStateException("joint time in container is not plausible for personLeavingContainer=" + personLeavingContainer.getPersonId() + " and otherPerson=" + otherPerson.getPersonId() + ". Joint time is=" + jointTimeInContainer);
             }
 
-            double contactIntensity = getContactIntensity(container, infectionSituation, leavingPersonsActivity, otherPersonsActivity);
-
+            double contactIntensity = -1;
+            for (EpisimConfigGroup.InfectionParams infectionParams : episimConfig.getContainerParams().values()) {
+                if (infectionParams.includesActivity(infectionType)) {
+                    contactIntensity = infectionParams.getContactIntensity();
+                }
+            }
+            if (contactIntensity < 0.) {
+                throw new IllegalStateException("contactIntensity for infectionType=" + infectionType + " is not defined.  There needs to be a " +
+                        "config entry for each infection type.");
+            }
 
             double infectionProba = 1 - Math.exp(-episimConfig.getCalibrationParameter() * contactIntensity * jointTimeInContainer);
             // note that for 1pct runs, calibParam is of the order of one, which means that for typical times of 100sec or more,
@@ -144,54 +132,6 @@ public class DefaultInfectionModel extends InfectionModel {
                 } else {
                     infectPerson(otherPerson, personLeavingContainer, now, infectionType);
                 }
-            }
-        }
-    }
-
-    private double getContactIntensity(EpisimContainer<?> container, InfectionSituation infectionSituation, String leavingPersonsActivity, String otherPersonsActivity) {
-        double contactIntensity = -1;
-        if(infectionSituation.equals(InfectionSituation.Vehicle)){
-            if(! (container instanceof InfectionEventHandler.EpisimVehicle) ){
-                throw new IllegalArgumentException();
-            }
-            String containerIdString = container.getContainerId().toString();
-
-            for (EpisimConfigGroup.InfectionParams infectionParams : episimConfig.getContainerParams().values()) {
-                if(infectionParams.includesActivity(containerIdString)){
-                    contactIntensity = infectionParams.getContactIntensity();
-                }
-            }
-            if(contactIntensity < 0.){
-                throw new IllegalStateException("contactIntensity not defined for vehicle container=" + containerIdString + ".  There needs to be a config entry for each activity type.");
-            }
-        } else{
-            double contactIntensityLeavingPerson = -1;
-            double contactIntensityOtherPerson = -1;
-            for (EpisimConfigGroup.InfectionParams infectionParams : episimConfig.getContainerParams().values()) {
-                if (infectionParams.includesActivity(leavingPersonsActivity)) {
-                    contactIntensityLeavingPerson = infectionParams.getContactIntensity();
-                }
-                if(infectionParams.includesActivity(otherPersonsActivity)){
-                    contactIntensityOtherPerson = infectionParams.getContactIntensity();
-                }
-            }
-            if (contactIntensityLeavingPerson < 0. || contactIntensityOtherPerson < 0.) {
-                throw new IllegalStateException("contactIntensity not defined either for activityType=" + contactIntensityLeavingPerson + " or for activityType= " + otherPersonsActivity
-                        + ".  There needs to be a config entry for each activity type.");
-            }
-
-            contactIntensity = Math.max(contactIntensityLeavingPerson, contactIntensityOtherPerson);
-        }
-        return contactIntensity;
-    }
-
-    private void trackContactPerson(EpisimPerson personLeavingContainer, EpisimPerson otherPerson, String leavingPersonsActivity) {
-        if (leavingPersonsActivity.contains("home") || leavingPersonsActivity.contains("work") || (leavingPersonsActivity.contains("leisure") && rnd.nextDouble() < 0.8)) {
-            if (!personLeavingContainer.getTraceableContactPersons().contains(otherPerson)) {
-                personLeavingContainer.addTraceableContactPerson(otherPerson);
-            }
-            if (!otherPerson.getTraceableContactPersons().contains(personLeavingContainer)) {
-                otherPerson.addTraceableContactPerson(personLeavingContainer);
             }
         }
     }

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -149,6 +149,7 @@ public class DefaultInfectionModel extends InfectionModel {
     }
 
     private double getContactIntensity(EpisimContainer<?> container, InfectionSituation infectionSituation, String leavingPersonsActivity, String otherPersonsActivity) {
+        //TODO maybe this can be cleaned up or summarized in some way
         double contactIntensity = -1;
         if(infectionSituation.equals(InfectionSituation.Vehicle)){
             if(! (container instanceof InfectionEventHandler.EpisimVehicle) ){

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -63,8 +63,8 @@ public class DefaultInfectionModel extends InfectionModel {
             //  depend on the density), and then a probability of infection in either direction.
 
             //TODO the way we iterate here, chances exist that we do draw the same otherPerson twice, right? schlenther, march 27
-            int idx = rnd.nextInt(personsToInteractWith.size());
-            EpisimPerson otherPerson = personsToInteractWith.get(idx);
+            int idx = rnd.nextInt(container.getPersons().size());
+            EpisimPerson otherPerson = container.getPersons().get(idx);
 
             contactPersonsToFind --;
 

--- a/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/DefaultInfectionModel.java
@@ -46,10 +46,15 @@ public class DefaultInfectionModel extends InfectionModel {
 
         // For the time being, will just assume that the first 10 persons are the ones we interact with.  Note that because of
         // shuffle, those are 10 different persons every day.
+        // as sample size is 25%, 10 persons means 3 agents here
+        int contactPersonsToFind = Math.max((int) (episimConfig.getSampleSize() * 10), 3);
+        for ( int ii = 0 ; ii< personsToInteractWith.size(); ii++ ) {
+            //as we now forbid infection for certain activity type pairs, we do need the separate counter. schlenther, march 27
 
-        // persons are scaled to number of agents with sample size, but at least 3 for the small development scenarios
-        int contactWith = Math.min(personsToInteractWith.size(), Math.max((int) (episimConfig.getSampleSize() * 10), 3));
-        for (int ii = 0; ii < contactWith; ii++) {
+            //if we have seen enough, break, no matter what
+            if(contactPersonsToFind <= 0){
+                break;
+            }
 
             // (this is "-1" because we can't interact with "self")
 
@@ -60,6 +65,8 @@ public class DefaultInfectionModel extends InfectionModel {
             //TODO the way we iterate here, chances exist that we do draw the same otherPerson twice, right? schlenther, march 27
             int idx = rnd.nextInt(personsToInteractWith.size());
             EpisimPerson otherPerson = personsToInteractWith.get(idx);
+
+            contactPersonsToFind --;
 
             // (we count "quarantine" as well since they essentially represent "holes", i.e. persons who are no longer there and thus the
             // density in the transit container goes down.  kai, mar'20)

--- a/src/main/java/org/matsim/episim/model/InfectionModel.java
+++ b/src/main/java/org/matsim/episim/model/InfectionModel.java
@@ -84,17 +84,17 @@ public abstract class InfectionModel {
     /**
      * Checks whether a persons and container is relevant for the infection dynamics. This function also considers the restrictions in place.
      */
-    protected boolean isRelevantForInfectionDynamics(EpisimPerson personLeavingContainer, EpisimContainer<?> container) {
-        if (!EpisimUtils.hasStatusRelevantForInfectionDynamics(personLeavingContainer)) {
+    protected boolean isRelevantForInfectionDynamics(EpisimPerson person, EpisimContainer<?> container) {
+        if (!EpisimUtils.hasStatusRelevantForInfectionDynamics(person)) {
             return false;
         }
-        if (personLeavingContainer.getQuarantineStatus() == EpisimPerson.QuarantineStatus.full) {
+        if (person.getQuarantineStatus() == EpisimPerson.QuarantineStatus.full) {
             return false;
         }
-        if (container instanceof InfectionEventHandler.EpisimFacility && activityRelevantForInfectionDynamics(personLeavingContainer)) {
+        if (container instanceof InfectionEventHandler.EpisimFacility && activityRelevantForInfectionDynamics(person)) {
             return true;
         }
-        if (container instanceof InfectionEventHandler.EpisimVehicle && tripRelevantForInfectionDynamics(personLeavingContainer)) {
+        if (container instanceof InfectionEventHandler.EpisimVehicle && tripRelevantForInfectionDynamics(person)) {
             return true;
         }
         return false;

--- a/src/main/java/org/matsim/episim/policy/FixedPolicy.java
+++ b/src/main/java/org/matsim/episim/policy/FixedPolicy.java
@@ -52,10 +52,11 @@ public class FixedPolicy extends ShutdownPolicy {
          * @param day        the day/iteration when it will be in effect
          * @param fraction   fraction of remaining allowed activity
          */
+        @SuppressWarnings("unchecked")
         public ConfigBuilder restrict(long day, double fraction, String... activities) {
 
             for (String act : activities) {
-                Map<String, Double> p = params.computeIfAbsent(act, m -> new HashMap<>());
+                Map<String, Double> p = (Map<String, Double>) params.computeIfAbsent(act, m -> new HashMap<>());
                 p.put(String.valueOf(day), fraction);
             }
 

--- a/src/main/java/org/matsim/episim/policy/ShutdownPolicy.java
+++ b/src/main/java/org/matsim/episim/policy/ShutdownPolicy.java
@@ -81,7 +81,7 @@ public abstract class ShutdownPolicy {
      */
     static class ConfigBuilder {
 
-        protected Map<String, Map<String, Double>> params = new HashMap<>();
+        protected Map<String, Object> params = new HashMap<>();
 
         public Config build() {
             return ConfigFactory.parseMap(params);

--- a/src/main/java/org/matsim/run/RunEpisim.java
+++ b/src/main/java/org/matsim/run/RunEpisim.java
@@ -120,13 +120,13 @@ public class RunEpisim {
         if (!Files.exists(out))
             Files.createDirectories(out);
 
+        EpisimConfigGroup episimConfig = ConfigUtils.addOrGetModule(config, EpisimConfigGroup.class);
+
         EventsManager events = EventsUtils.createEventsManager();
         events.addHandler(new InfectionEventHandler(config));
 
         List<Event> allEvents = new ArrayList<>();
         events.addHandler(new ReplayHandler(allEvents));
-
-        EpisimConfigGroup episimConfig = ConfigUtils.addOrGetModule(config, EpisimConfigGroup.class);
 
         ControlerUtils.checkConfigConsistencyAndWriteToLog(config, "Just before starting iterations");
 


### PR DESCRIPTION
in the snz scenario, agents can perform activities of different types in the same episimcontainer.
we might want to forbid infection for certain activity type pairs such as home <-> shopping.

when different activity types are allowed, the defined contact intentisities can differ.