### PR TITLE
call the InfectionEventHandler directly in replayEvents (performance improvment)

### DIFF
--- a/src/main/java/org/matsim/episim/EpisimRunner.java
+++ b/src/main/java/org/matsim/episim/EpisimRunner.java
@@ -82,6 +82,8 @@ public final class EpisimRunner {
 		final InfectionEventHandler handler = handlerProvider.get();
 		final EpisimReporting reporting = reportingProvider.get();
 
+		replay.setInfectionsHandler(handler);
+
 		// reporting will write events if necessary
 		EpisimConfigGroup episimConfig = ConfigUtils.addOrGetModule(config, EpisimConfigGroup.class);
 


### PR DESCRIPTION
I also tried to implement the infectionHandler depency via Guice, but gave up because of the SplitHomeFacilities use case of the ReplayHandler.

