### PR TITLE
InfectionEventHandler.shouldHandle... functions called from ReplayHandler

### DIFF
--- a/src/main/java/org/matsim/episim/InfectionEventHandler.java
+++ b/src/main/java/org/matsim/episim/InfectionEventHandler.java
@@ -474,10 +474,6 @@ public final class InfectionEventHandler implements ActivityEndEventHandler, Per
 //		double now = activityStartEvent.getTime();
 		double now = EpisimUtils.getCorrectedTime(episimConfig.getStartOffset(), activityStartEvent.getTime(), iteration);
 
-		if (!shouldHandleActivityEvent(activityStartEvent, activityStartEvent.getActType())) {
-			return;
-		}
-
 		// find the person:
 		EpisimPerson episimPerson = this.personMap.get(activityStartEvent.getPersonId());
 
@@ -500,11 +496,6 @@ public final class InfectionEventHandler implements ActivityEndEventHandler, Per
 //		double now = activityEndEvent.getTime();
 		double now = EpisimUtils.getCorrectedTime(episimConfig.getStartOffset(), activityEndEvent.getTime(), iteration);
 
-
-		if (!shouldHandleActivityEvent(activityEndEvent, activityEndEvent.getActType())) {
-			return;
-		}
-
 		EpisimPerson episimPerson = this.personMap.get(activityEndEvent.getPersonId());
 		Id<ActivityFacility> episimFacilityId = createEpisimFacilityId(activityEndEvent);
 
@@ -521,18 +512,12 @@ public final class InfectionEventHandler implements ActivityEndEventHandler, Per
 		episimFacility.removePerson(episimPerson);
 
 		handlePersonTrajectory(episimPerson.getPersonId(), activityEndEvent.getActType());
-
 	}
 
 	@Override
 	public void handleEvent(PersonEntersVehicleEvent entersVehicleEvent) {
 //		double now = entersVehicleEvent.getTime();
 		double now = EpisimUtils.getCorrectedTime(episimConfig.getStartOffset(), entersVehicleEvent.getTime(), iteration);
-
-
-		if (!shouldHandlePersonEvent(entersVehicleEvent)) {
-			return;
-		}
 
 		// find the person:
 		EpisimPerson episimPerson = this.personMap.get(entersVehicleEvent.getPersonId());
@@ -550,11 +535,6 @@ public final class InfectionEventHandler implements ActivityEndEventHandler, Per
 	public void handleEvent(PersonLeavesVehicleEvent leavesVehicleEvent) {
 //		double now = leavesVehicleEvent.getTime();
 		double now = EpisimUtils.getCorrectedTime(episimConfig.getStartOffset(), leavesVehicleEvent.getTime(), iteration);
-
-
-		if (!shouldHandlePersonEvent(leavesVehicleEvent)) {
-			return;
-		}
 
 		// find vehicle:
 		EpisimVehicle episimVehicle = this.vehicleMap.get(leavesVehicleEvent.getVehicleId());

--- a/src/main/java/org/matsim/episim/ReplayHandler.java
+++ b/src/main/java/org/matsim/episim/ReplayHandler.java
@@ -27,9 +27,11 @@ import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.Event;
+import org.matsim.api.core.v01.events.PersonEntersVehicleEvent;
+import org.matsim.api.core.v01.events.PersonLeavesVehicleEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.api.experimental.events.EventsManager;
@@ -155,6 +157,11 @@ public final class ReplayHandler {
 			// Add coordinate information if not present
 			if (event instanceof ActivityStartEvent) {
 				ActivityStartEvent e = (ActivityStartEvent) event;
+
+				if (!InfectionEventHandler.shouldHandleActivityEvent(e, e.getActType())) {
+					return;
+				}
+
 				Coord coord = e.getCoord();
 				if (coord == null && scenario != null && scenario.getNetwork().getLinks().containsKey(e.getLinkId())) {
 					Link link = scenario.getNetwork().getLinks().get(e.getLinkId());
@@ -168,6 +175,11 @@ public final class ReplayHandler {
 				event = new ActivityStartEvent(e.getTime(), e.getPersonId(), e.getLinkId(), e.getFacilityId(), e.getActType().intern(), coord);
 			} else if (event instanceof ActivityEndEvent) {
 				ActivityEndEvent e = (ActivityEndEvent) event;
+
+				if (!InfectionEventHandler.shouldHandleActivityEvent(e, e.getActType())) {
+					return;
+				}
+
 				String actType = e.getActType().intern();
 				double time = e.getTime();
 
@@ -184,10 +196,22 @@ public final class ReplayHandler {
 				}
 
 				event = new ActivityEndEvent(time, e.getPersonId(), e.getLinkId(), e.getFacilityId(), actType);
+			} else if (event instanceof PersonEntersVehicleEvent) {
+				if (!InfectionEventHandler.shouldHandlePersonEvent((PersonEntersVehicleEvent) event)) {
+					return;
+				}
+			} else if (event instanceof PersonLeavesVehicleEvent) {
+				if (!InfectionEventHandler.shouldHandlePersonEvent((PersonLeavesVehicleEvent) event)) {
+					return;
+				}
 			}
 
 			events.add(event);
 		}
+
+
 	}
+
+
 
 }


### PR DESCRIPTION
I have here the same problem as with the createEpisimFacilityId. The InfectionEventHandler also calls the shouldHandle functions in the init method, and I'm not sure if I can remove them there after the change of the handleEvent method.