### PR TITLE
restructed InfectionEventHandler (Performance Improvment)

### DIFF
--- a/src/main/java/org/matsim/episim/EpisimRunner.java
+++ b/src/main/java/org/matsim/episim/EpisimRunner.java
@@ -142,7 +142,7 @@ public final class EpisimRunner {
 		DayOfWeek day = EpisimUtils.getDayOfWeek(ConfigUtils.addOrGetModule(config, EpisimConfigGroup.class).getStartDate(), iteration);
 
 		// Process all events
-		replay.replayEvents(manager, day);
+		replay.replayEvents(handler, day);
 
 		reporting.flushEvents();
 

--- a/src/main/java/org/matsim/scenarioCreation/FilterHandler.java
+++ b/src/main/java/org/matsim/scenarioCreation/FilterHandler.java
@@ -28,7 +28,7 @@ import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonLeavesVehicleEventHandler;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
-import org.matsim.episim.InfectionEventHandler;
+import org.matsim.episim.ReplayHandler;
 import org.matsim.facilities.ActivityFacility;
 
 import javax.annotation.Nullable;
@@ -68,7 +68,7 @@ public class FilterHandler implements ActivityEndEventHandler, PersonEntersVehic
 	public void handleEvent(ActivityEndEvent activityEndEvent) {
 		counter++;
 
-		if (!InfectionEventHandler.shouldHandleActivityEvent(activityEndEvent, activityEndEvent.getActType()))
+		if (!ReplayHandler.shouldHandleActivityEvent(activityEndEvent, activityEndEvent.getActType()))
 			return;
 		if (population != null && !population.getPersons().containsKey(activityEndEvent.getPersonId()))
 			return;
@@ -92,7 +92,7 @@ public class FilterHandler implements ActivityEndEventHandler, PersonEntersVehic
 	public void handleEvent(ActivityStartEvent activityStartEvent) {
 		counter++;
 
-		if (!InfectionEventHandler.shouldHandleActivityEvent(activityStartEvent, activityStartEvent.getActType()))
+		if (!ReplayHandler.shouldHandleActivityEvent(activityStartEvent, activityStartEvent.getActType()))
 			return;
 		if (population != null && !population.getPersons().containsKey(activityStartEvent.getPersonId()))
 			return;
@@ -117,7 +117,7 @@ public class FilterHandler implements ActivityEndEventHandler, PersonEntersVehic
 	public void handleEvent(PersonEntersVehicleEvent personEntersVehicleEvent) {
 		counter++;
 
-		if (!InfectionEventHandler.shouldHandlePersonEvent(personEntersVehicleEvent))
+		if (!ReplayHandler.shouldHandlePersonEvent(personEntersVehicleEvent))
 			return;
 		if (population != null && !population.getPersons().containsKey(personEntersVehicleEvent.getPersonId()))
 			return;
@@ -131,7 +131,7 @@ public class FilterHandler implements ActivityEndEventHandler, PersonEntersVehic
 	public void handleEvent(PersonLeavesVehicleEvent personLeavesVehicleEvent) {
 		counter++;
 
-		if (!InfectionEventHandler.shouldHandlePersonEvent(personLeavesVehicleEvent))
+		if (!ReplayHandler.shouldHandlePersonEvent(personLeavesVehicleEvent))
 			return;
 		if (population != null && !population.getPersons().containsKey(personLeavesVehicleEvent.getPersonId()))
 			return;


### PR DESCRIPTION
All suggested performance improvement regarding the InfectionEventHandler in a single pull request. I also tried to rename the handleEvent functions to the concrete event types, this did work for the ActivityStart/EndEvents but not for the PersonEnters/LeavesVehicleEvent, the later causes failures in the tests with not matching facility ids, so I didn't changed the function names.